### PR TITLE
Catch SiteNotFound exception for pages without site configuration

### DIFF
--- a/Classes/Domain/Repository/SessionRepository.php
+++ b/Classes/Domain/Repository/SessionRepository.php
@@ -185,9 +185,13 @@ class SessionRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
 			if ( $row["pdeleted"] ) {
 			    $row['domain'] = '';
 			} else {
-    			$site = $siteFinder->getSiteByPageId($row['pid']);
-    			$base = $site->getConfiguration()['base'];
-    			$row['domain'] = rtrim($base, '/');
+				try {
+					$site = $siteFinder->getSiteByPageId($row['pid']);
+					$base = $site->getConfiguration()['base'];
+					$row['domain'] = rtrim($base, '/');
+				} catch (SiteNotFoundException $e) {
+					$row['domain'] = 'SiteNotFound';
+				}
 			}
 			$row['csvtitle'] = str_replace(';', ',', str_replace('"', '', $row['title']));
 			$pages[] = $row;

--- a/Resources/Private/Templates/Session/List.html
+++ b/Resources/Private/Templates/Session/List.html
@@ -75,7 +75,7 @@
 	<f:then>
 		<textarea name="dummy" rows="12" cols="120">
 Content element;;;;;;;;Page;;
-uid;lang.;colPos;deleted;hidden;header;CType;list tyle;FlexForm actions;uid;deleted;hidden;title
+uid;lang.;colPos;deleted;hidden;header;CType;list_type;FlexForm actions;uid;deleted;hidden;title
 <f:for each="{pages}" as="page" iteration="iterator">{page.uid};{page.sys_language_uid};{page.colPos};{page.ttdeleted};{page.tthidden};"{page.csvheader}";{page.CType};{page.list_type};<f:format.raw>{page.actions}</f:format.raw>;{page.pid};{page.pdeleted};{page.phidden};"{page.csvtitle}"
 </f:for></textarea>
 	</f:then>
@@ -94,7 +94,7 @@ uid;lang.;colPos;deleted;hidden;header;CType;list tyle;FlexForm actions;uid;dele
 				<th>deleted / hidden</th>
 				<th>header</th>
 				<th>CType</th>
-				<th>list tyle</th>
+				<th>list_type</th>
 				<th>FlexForm actions</th>
 				<th>uid</th>
 				<th>deleted / hidden</th>


### PR DESCRIPTION
If you have folders outside the site root pages containing content, 
or inconsistencies like lost pages whose parent has been deleted,
then this fix catches the exception and backendtools keeps working.